### PR TITLE
Explicitly clear the aura count when it's zero.

### DIFF
--- a/Elements/Plugins/Aura_Plugin.lua
+++ b/Elements/Plugins/Aura_Plugin.lua
@@ -234,6 +234,8 @@ local function updateIcon(element, unit, index, offset, filter, isDebuff, visibl
 			if(button.count) then
 				if count > 1 and count then
 					button.count:SetText(count)
+				else
+					button.count:SetText("")
 				end
 			end
 


### PR DESCRIPTION
When a new aura fills the spot that an aura with a non-zero count used to occupy, make sure that the old aura's stack size is cleared when displaying the new aura.